### PR TITLE
Fixed `lve_pipeline.hpp`

### DIFF
--- a/littleVulkanEngine/tutorial18/lve_pipeline.hpp
+++ b/littleVulkanEngine/tutorial18/lve_pipeline.hpp
@@ -9,6 +9,7 @@
 namespace lve {
 
 struct PipelineConfigInfo {
+  PipelineConfigInfo() = default;
   PipelineConfigInfo(const PipelineConfigInfo&) = delete;
   PipelineConfigInfo& operator=(const PipelineConfigInfo&) = delete;
 


### PR DESCRIPTION
Fixed error about missing constructor `PipelineConfigInfo::PipelineConfigInfo`