### PR TITLE
tutorial 19 LveBuffer fix and ROOT_PATH macro

### DIFF
--- a/littleVulkanEngine/tutorial19/lve_buffer.cpp
+++ b/littleVulkanEngine/tutorial19/lve_buffer.cpp
@@ -63,9 +63,6 @@ LveBuffer::~LveBuffer() {
  */
 VkResult LveBuffer::map(VkDeviceSize size, VkDeviceSize offset) {
   assert(buffer && memory && "Called map on buffer before create");
-  if (size == VK_WHOLE_SIZE) {
-    return vkMapMemory(lveDevice.device(), memory, 0, bufferSize, 0, &mapped);
-  }
   return vkMapMemory(lveDevice.device(), memory, offset, size, 0, &mapped);
 }
 

--- a/littleVulkanEngine/tutorial19/lve_model.cpp
+++ b/littleVulkanEngine/tutorial19/lve_model.cpp
@@ -1,3 +1,7 @@
+#ifndef ROOT_PATH
+#define ROOT_PATH ""
+#endif
+
 #include "lve_model.hpp"
 
 #include "lve_utils.hpp"
@@ -35,8 +39,11 @@ LveModel::~LveModel() {}
 
 std::unique_ptr<LveModel> LveModel::createModelFromFile(
     LveDevice &device, const std::string &filepath) {
+  std::string absPath = ROOT_PATH;
+  absPath += filepath;
+
   Builder builder{};
-  builder.loadModel(filepath);
+  builder.loadModel(absPath);
   return std::make_unique<LveModel>(device, builder);
 }
 

--- a/littleVulkanEngine/tutorial19/lve_pipeline.cpp
+++ b/littleVulkanEngine/tutorial19/lve_pipeline.cpp
@@ -1,3 +1,7 @@
+#ifndef ROOT_PATH
+#define ROOT_PATH ""
+#endif
+
 #include "lve_pipeline.hpp"
 
 #include "lve_model.hpp"
@@ -26,10 +30,13 @@ LvePipeline::~LvePipeline() {
 }
 
 std::vector<char> LvePipeline::readFile(const std::string& filepath) {
-  std::ifstream file{filepath, std::ios::ate | std::ios::binary};
+  std::string absPath = ROOT_PATH;
+  absPath += filepath;
+
+  std::ifstream file{absPath, std::ios::ate | std::ios::binary};
 
   if (!file.is_open()) {
-    throw std::runtime_error("failed to open file: " + filepath);
+    throw std::runtime_error("failed to open file: " + absPath);
   }
 
   size_t fileSize = static_cast<size_t>(file.tellg());


### PR DESCRIPTION
This PR merges the fix to LveBuffer validation error found on my system, per Brendan's instruction.

Also, I added a ROOT_PATH macro that can be set in compiler options to provide the ability to read files from a path prefix. If the compiler doesn't declare ROOT_PATH, then it defaults to an empty string in code and is read from the executables current working path. This was done in an effort to use cmake outside the repo folder without having to make any changes to the repo.

My dev folder layout looks like:
- build (folder)
- littleVulkanEngine (repo folder)
- CMakeLists.txt (cmake config)
- .env (file) - sets the path prefix for cmake config and loading shaders/models
  - export LVE_PATH=$(pwd)/littleVulkanEngine/littleVulkanEngine/tutorial19