### PR TITLE
Tutorial 26 - Specular Lighting

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,6 +127,12 @@ In this tutorial we add support for multiple point light objects in the scene. L
 
 ([Video](https://youtu.be/1olS6ayckKM))
 
+#### [26 - Specular Lighting](https://github.com/blurrypiano/littleVulkanEngine/tree/tut26)
+
+In this tutorial we add specular lighting to our simple fragment shader.
+
+([Video](https://youtu.be/8CTr0SKQ21U))
+
 ## <a name="Khronossamples"></a> Official Khronos Vulkan Samples
 
 Khronos made an official Vulkan Samples repository available to the public ([press release](https://www.khronos.org/blog/vulkan-releases-unified-samples-repository?utm_source=Khronos%20Blog&utm_medium=Twitter&utm_campaign=Vulkan%20Repository)).

--- a/shaders/point_light.frag
+++ b/shaders/point_light.frag
@@ -11,6 +11,7 @@ struct PointLight {
 layout(set = 0, binding = 0) uniform GlobalUbo {
   mat4 projection;
   mat4 view;
+  mat4 invView;
   vec4 ambientLightColor; // w is intensity
   PointLight pointLights[10];
   int numLights;

--- a/shaders/point_light.vert
+++ b/shaders/point_light.vert
@@ -19,6 +19,7 @@ struct PointLight {
 layout(set = 0, binding = 0) uniform GlobalUbo {
   mat4 projection;
   mat4 view;
+  mat4 invView;
   vec4 ambientLightColor; // w is intensity
   PointLight pointLights[10];
   int numLights;

--- a/shaders/simple_shader.frag
+++ b/shaders/simple_shader.frag
@@ -48,9 +48,9 @@ void main() {
     vec3 halfAngle = normalize(directionToLight + viewDirection);
     float blinnTerm = dot(surfaceNormal, halfAngle);
     blinnTerm = clamp(blinnTerm, 0, 1);
-    blinnTerm = pow(blinnTerm, 40.0); // higher values -> sharper highlight
+    blinnTerm = pow(blinnTerm, 512.0); // higher values -> sharper highlight
     specularLight += intensity * blinnTerm;
   }
   
-  outColor = vec4(specularLight * fragColor, 1.0);
+  outColor = vec4(diffuseLight * fragColor + specularLight * fragColor, 1.0);
 }

--- a/shaders/simple_shader.frag
+++ b/shaders/simple_shader.frag
@@ -14,6 +14,7 @@ struct PointLight {
 layout(set = 0, binding = 0) uniform GlobalUbo {
   mat4 projection;
   mat4 view;
+  mat4 invView;
   vec4 ambientLightColor; // w is intensity
   PointLight pointLights[10];
   int numLights;
@@ -26,17 +27,30 @@ layout(push_constant) uniform Push {
 
 void main() {
   vec3 diffuseLight = ubo.ambientLightColor.xyz * ubo.ambientLightColor.w;
+  vec3 specularLight = vec3(0.0);
   vec3 surfaceNormal = normalize(fragNormalWorld);
+
+  vec3 cameraPosWorld = ubo.invView[3].xyz;
+  vec3 viewDirection = normalize(cameraPosWorld - fragPosWorld);
 
   for (int i = 0; i < ubo.numLights; i++) {
     PointLight light = ubo.pointLights[i];
     vec3 directionToLight = light.position.xyz - fragPosWorld;
     float attenuation = 1.0 / dot(directionToLight, directionToLight); // distance squared
-    float cosAngIncidence = max(dot(surfaceNormal, normalize(directionToLight)), 0);
+    directionToLight = normalize(directionToLight);
+
+    float cosAngIncidence = max(dot(surfaceNormal, directionToLight), 0);
     vec3 intensity = light.color.xyz * light.color.w * attenuation;
 
     diffuseLight += intensity * cosAngIncidence;
+
+    // specular lighting
+    vec3 halfAngle = normalize(directionToLight + viewDirection);
+    float blinnTerm = dot(surfaceNormal, halfAngle);
+    blinnTerm = clamp(blinnTerm, 0, 1);
+    blinnTerm = pow(blinnTerm, 40.0); // higher values -> sharper highlight
+    specularLight += intensity * blinnTerm;
   }
   
-  outColor = vec4(diffuseLight * fragColor, 1.0);
+  outColor = vec4(specularLight * fragColor, 1.0);
 }

--- a/shaders/simple_shader.vert
+++ b/shaders/simple_shader.vert
@@ -17,6 +17,7 @@ struct PointLight {
 layout(set = 0, binding = 0) uniform GlobalUbo {
   mat4 projection;
   mat4 view;
+  mat4 invView;
   vec4 ambientLightColor; // w is intensity
   PointLight pointLights[10];
   int numLights;

--- a/src/first_app.cpp
+++ b/src/first_app.cpp
@@ -99,6 +99,7 @@ void FirstApp::run() {
       GlobalUbo ubo{};
       ubo.projection = camera.getProjection();
       ubo.view = camera.getView();
+      ubo.inverseView = camera.getInverseView();
       pointLightSystem.update(frameInfo, ubo);
       uboBuffers[frameIndex]->writeToBuffer(&ubo);
       uboBuffers[frameIndex]->flush();

--- a/src/lve_camera.cpp
+++ b/src/lve_camera.cpp
@@ -46,6 +46,20 @@ void LveCamera::setViewDirection(glm::vec3 position, glm::vec3 direction, glm::v
   viewMatrix[3][0] = -glm::dot(u, position);
   viewMatrix[3][1] = -glm::dot(v, position);
   viewMatrix[3][2] = -glm::dot(w, position);
+
+  inverseViewMatrix = glm::mat4{1.f};
+  inverseViewMatrix[0][0] = u.x;
+  inverseViewMatrix[0][1] = u.y;
+  inverseViewMatrix[0][2] = u.z;
+  inverseViewMatrix[1][0] = v.x;
+  inverseViewMatrix[1][1] = v.y;
+  inverseViewMatrix[1][2] = v.z;
+  inverseViewMatrix[2][0] = w.x;
+  inverseViewMatrix[2][1] = w.y;
+  inverseViewMatrix[2][2] = w.z;
+  inverseViewMatrix[3][0] = position.x;
+  inverseViewMatrix[3][1] = position.y;
+  inverseViewMatrix[3][2] = position.z;
 }
 
 void LveCamera::setViewTarget(glm::vec3 position, glm::vec3 target, glm::vec3 up) {
@@ -75,6 +89,20 @@ void LveCamera::setViewYXZ(glm::vec3 position, glm::vec3 rotation) {
   viewMatrix[3][0] = -glm::dot(u, position);
   viewMatrix[3][1] = -glm::dot(v, position);
   viewMatrix[3][2] = -glm::dot(w, position);
+
+  inverseViewMatrix = glm::mat4{1.f};
+  inverseViewMatrix[0][0] = u.x;
+  inverseViewMatrix[0][1] = u.y;
+  inverseViewMatrix[0][2] = u.z;
+  inverseViewMatrix[1][0] = v.x;
+  inverseViewMatrix[1][1] = v.y;
+  inverseViewMatrix[1][2] = v.z;
+  inverseViewMatrix[2][0] = w.x;
+  inverseViewMatrix[2][1] = w.y;
+  inverseViewMatrix[2][2] = w.z;
+  inverseViewMatrix[3][0] = position.x;
+  inverseViewMatrix[3][1] = position.y;
+  inverseViewMatrix[3][2] = position.z;
 }
 
 }  // namespace lve

--- a/src/lve_camera.hpp
+++ b/src/lve_camera.hpp
@@ -21,9 +21,11 @@ class LveCamera {
 
   const glm::mat4& getProjection() const { return projectionMatrix; }
   const glm::mat4& getView() const { return viewMatrix; }
+  const glm::mat4& getInverseView() const { return inverseViewMatrix; }
 
  private:
   glm::mat4 projectionMatrix{1.f};
   glm::mat4 viewMatrix{1.f};
+  glm::mat4 inverseViewMatrix{1.f};
 };
 }  // namespace lve

--- a/src/lve_frame_info.hpp
+++ b/src/lve_frame_info.hpp
@@ -18,6 +18,7 @@ struct PointLight {
 struct GlobalUbo {
   glm::mat4 projection{1.f};
   glm::mat4 view{1.f};
+  glm::mat4 inverseView{1.f};
   glm::vec4 ambientLightColor{1.f, 1.f, 1.f, .02f};  // w is intensity
   PointLight pointLights[MAX_LIGHTS];
   int numLights;

--- a/tutorials/tut26.md
+++ b/tutorials/tut26.md
@@ -10,7 +10,7 @@ Specular lighting represents shiny materials by modelling the reflection of ligh
 
 [View branch](https://github.com/blurrypiano/littleVulkanEngine/tree/tut26)
 
-[View Files Changed](https://github.com/blurrypiano/littleVulkanEngine/pull/28/files)
+[View Files Changed](https://github.com/blurrypiano/littleVulkanEngine/pull/30/files)
 
 [Video Tutorial](https://youtu.be/8CTr0SKQ21U)
 

--- a/tutorials/tut26.md
+++ b/tutorials/tut26.md
@@ -1,0 +1,21 @@
+# Specular Lighting - Tutorial 26
+
+Specular lighting represents shiny materials by modelling the reflection of light sources on the object. Shiny materials reflect light more strongly in the direction opposite the angle of incidence. This means that unlike diffuse lighting, the position of the camera/viewer now plays a role in the lighting calculation.
+
+#### Paste Bin Links
+
+[Inverse View Matrix](https://pastebin.com/wBAEhNjz)
+
+#### Tutorial Links
+
+[View branch](https://github.com/blurrypiano/littleVulkanEngine/tree/tut26)
+
+[View Files Changed](https://github.com/blurrypiano/littleVulkanEngine/pull/28/files)
+
+[Video Tutorial](https://youtu.be/8CTr0SKQ21U)
+
+## Further Reading and Video Resources
+
+[Chapter 11 of this great resource](https://paroj.github.io/gltut/Illumination/Tutorial%2011.html)
+
+[Learn OpenGL - Basic Lighting](https://learnopengl.com/Lighting/Basic-Lighting)


### PR DESCRIPTION
# Specular Lighting - Tutorial 26

Specular lighting represents shiny materials by modelling the reflection of light sources on the object. Shiny materials reflect light more strongly in the direction opposite the angle of incidence. This means that unlike diffuse lighting, the position of the camera/viewer now plays a role in the lighting calculation.

#### Paste Bin Links

[Inverse View Matrix](https://pastebin.com/wBAEhNjz)

#### Tutorial Links

[View branch](https://github.com/blurrypiano/littleVulkanEngine/tree/tut26)

[View Files Changed](https://github.com/blurrypiano/littleVulkanEngine/pull/28/files)

[Video Tutorial](https://youtu.be/8CTr0SKQ21U)

## Further Reading and Video Resources

[Chapter 11 of this great resource](https://paroj.github.io/gltut/Illumination/Tutorial%2011.html)

[Learn OpenGL - Basic Lighting](https://learnopengl.com/Lighting/Basic-Lighting)
