### PR TITLE
Alpha Blending and Transparency - Tutorial 27

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,6 +133,12 @@ In this tutorial we add specular lighting to our simple fragment shader.
 
 ([Video](https://youtu.be/8CTr0SKQ21U))
 
+#### [27 - Alpha Blending and Transparency](https://github.com/blurrypiano/littleVulkanEngine/tree/tut27)
+
+In this tutorial we add a limited blending capability to our point light system, allowing them to be rendered with a nicer appearance. 
+
+([Video](https://youtu.be/uZqxj6tLDY4))
+
 ## <a name="Khronossamples"></a> Official Khronos Vulkan Samples
 
 Khronos made an official Vulkan Samples repository available to the public ([press release](https://www.khronos.org/blog/vulkan-releases-unified-samples-repository?utm_source=Khronos%20Blog&utm_medium=Twitter&utm_campaign=Vulkan%20Repository)).

--- a/shaders/point_light.frag
+++ b/shaders/point_light.frag
@@ -23,10 +23,14 @@ layout(push_constant) uniform Push {
   float radius;
 } push;
 
+const float M_PI = 3.1415926538;
+
 void main() {
   float dis = sqrt(dot(fragOffset, fragOffset));
   if (dis >= 1.0) {
     discard;
   }
-  outColor = vec4(push.color.xyz, 1.0);
+
+  float cosDis = 0.5 * (cos(dis * M_PI) + 1.0); // ranges from 1 -> 0
+  outColor = vec4(push.color.xyz + 0.5 * cosDis, cosDis);
 }

--- a/src/first_app.cpp
+++ b/src/first_app.cpp
@@ -106,8 +106,11 @@ void FirstApp::run() {
 
       // render
       lveRenderer.beginSwapChainRenderPass(commandBuffer);
+
+      // order here matters
       simpleRenderSystem.renderGameObjects(frameInfo);
       pointLightSystem.render(frameInfo);
+
       lveRenderer.endSwapChainRenderPass(commandBuffer);
       lveRenderer.endFrame();
     }

--- a/src/lve_camera.hpp
+++ b/src/lve_camera.hpp
@@ -22,6 +22,7 @@ class LveCamera {
   const glm::mat4& getProjection() const { return projectionMatrix; }
   const glm::mat4& getView() const { return viewMatrix; }
   const glm::mat4& getInverseView() const { return inverseViewMatrix; }
+  const glm::vec3 getPosition() const { return glm::vec3(inverseViewMatrix[3]); }
 
  private:
   glm::mat4 projectionMatrix{1.f};

--- a/src/lve_pipeline.cpp
+++ b/src/lve_pipeline.cpp
@@ -210,4 +210,17 @@ void LvePipeline::defaultPipelineConfigInfo(PipelineConfigInfo& configInfo) {
   configInfo.attributeDescriptions = LveModel::Vertex::getAttributeDescriptions();
 }
 
+void LvePipeline::enableAlphaBlending(PipelineConfigInfo& configInfo) {
+  configInfo.colorBlendAttachment.blendEnable = VK_TRUE;
+  configInfo.colorBlendAttachment.colorWriteMask =
+      VK_COLOR_COMPONENT_R_BIT | VK_COLOR_COMPONENT_G_BIT | VK_COLOR_COMPONENT_B_BIT |
+      VK_COLOR_COMPONENT_A_BIT;
+  configInfo.colorBlendAttachment.srcColorBlendFactor = VK_BLEND_FACTOR_SRC_ALPHA;
+  configInfo.colorBlendAttachment.dstColorBlendFactor = VK_BLEND_FACTOR_ONE_MINUS_SRC_ALPHA;
+  configInfo.colorBlendAttachment.colorBlendOp = VK_BLEND_OP_ADD;
+  configInfo.colorBlendAttachment.srcAlphaBlendFactor = VK_BLEND_FACTOR_ONE;
+  configInfo.colorBlendAttachment.dstAlphaBlendFactor = VK_BLEND_FACTOR_ZERO;
+  configInfo.colorBlendAttachment.alphaBlendOp = VK_BLEND_OP_ADD;
+}
+
 }  // namespace lve

--- a/src/lve_pipeline.hpp
+++ b/src/lve_pipeline.hpp
@@ -9,6 +9,7 @@
 namespace lve {
 
 struct PipelineConfigInfo {
+  PipelineConfigInfo() = default;
   PipelineConfigInfo(const PipelineConfigInfo&) = delete;
   PipelineConfigInfo& operator=(const PipelineConfigInfo&) = delete;
 
@@ -43,6 +44,7 @@ class LvePipeline {
   void bind(VkCommandBuffer commandBuffer);
 
   static void defaultPipelineConfigInfo(PipelineConfigInfo& configInfo);
+  static void enableAlphaBlending(PipelineConfigInfo& configInfo);
 
  private:
   static std::vector<char> readFile(const std::string& filepath);

--- a/src/systems/point_light_system.cpp
+++ b/src/systems/point_light_system.cpp
@@ -9,6 +9,7 @@
 // std
 #include <array>
 #include <cassert>
+#include <map>
 #include <stdexcept>
 
 namespace lve {
@@ -55,6 +56,7 @@ void PointLightSystem::createPipeline(VkRenderPass renderPass) {
 
   PipelineConfigInfo pipelineConfig{};
   LvePipeline::defaultPipelineConfigInfo(pipelineConfig);
+  LvePipeline::enableAlphaBlending(pipelineConfig);
   pipelineConfig.attributeDescriptions.clear();
   pipelineConfig.bindingDescriptions.clear();
   pipelineConfig.renderPass = renderPass;
@@ -88,6 +90,18 @@ void PointLightSystem::update(FrameInfo& frameInfo, GlobalUbo& ubo) {
 }
 
 void PointLightSystem::render(FrameInfo& frameInfo) {
+  // sort lights
+  std::map<float, LveGameObject::id_t> sorted;
+  for (auto& kv : frameInfo.gameObjects) {
+    auto& obj = kv.second;
+    if (obj.pointLight == nullptr) continue;
+
+    // calculate distance
+    auto offset = frameInfo.camera.getPosition() - obj.transform.translation;
+    float disSquared = glm::dot(offset, offset);
+    sorted[disSquared] = obj.getId();
+  }
+
   lvePipeline->bind(frameInfo.commandBuffer);
 
   vkCmdBindDescriptorSets(
@@ -100,9 +114,10 @@ void PointLightSystem::render(FrameInfo& frameInfo) {
       0,
       nullptr);
 
-  for (auto& kv : frameInfo.gameObjects) {
-    auto& obj = kv.second;
-    if (obj.pointLight == nullptr) continue;
+  // iterate through sorted lights in reverse order
+  for (auto it = sorted.rbegin(); it != sorted.rend(); ++it) {
+    // use game obj id to find light object
+    auto& obj = frameInfo.gameObjects.at(it->second);
 
     PointLightPushConstants push{};
     push.position = glm::vec4(obj.transform.translation, 1.f);

--- a/tutorials/tut27.md
+++ b/tutorials/tut27.md
@@ -1,0 +1,19 @@
+# Alpha Blending and Transparency - Tutorial 27
+
+By setting a fragment's alpha to a value in between 0 and 1 we can render semi-transparent objects. Unfortunately things aren’t that simple. When working with semi-transparent objects, the order in which we render them actually matters!
+
+In this tutorial we add a limited blending capability to our point light system, allowing them to be rendered with a nicer appearance. 
+
+
+#### Tutorial Links
+
+[View branch](https://github.com/blurrypiano/littleVulkanEngine/tree/tut27)
+
+[View Files Changed](https://github.com/blurrypiano/littleVulkanEngine/pull/31/files)
+
+[Video Tutorial](https://youtu.be/uZqxj6tLDY4)
+
+## Further Reading and Video Resources
+
+[Learn OpenGL - Blending](https://learnopengl.com/Advanced-OpenGL/Blending)
+


### PR DESCRIPTION
By setting a fragment's alpha to a value in between 0 and 1 we can render semi-transparent objects. Unfortunately things aren’t that simple. When working with semi-transparent objects, the order in which we render them actually matters!

In this tutorial we add a limited blending capability to our point light system, allowing them to be rendered with a nicer appearance. 