### PR TITLE
Swapchain image count of 4 on some devices

### DIFF
--- a/src/lve_swap_chain.cpp
+++ b/src/lve_swap_chain.cpp
@@ -135,8 +135,10 @@ void LveSwapChain::createSwapChain() {
   VkSurfaceFormatKHR surfaceFormat = chooseSwapSurfaceFormat(swapChainSupport.formats);
   VkPresentModeKHR presentMode = chooseSwapPresentMode(swapChainSupport.presentModes);
   VkExtent2D extent = chooseSwapExtent(swapChainSupport.capabilities);
-
-  uint32_t imageCount = swapChainSupport.capabilities.minImageCount + 1;
+  
+  // hardcoded so that devices with minImageCount = 3 have the right number of sync objects
+  uint32_t imageCount = swapChainSupport.capabilities.minImageCount = 3;
+    
   if (swapChainSupport.capabilities.maxImageCount > 0 &&
       imageCount > swapChainSupport.capabilities.maxImageCount) {
     imageCount = swapChainSupport.capabilities.maxImageCount;

--- a/src/lve_swap_chain.cpp
+++ b/src/lve_swap_chain.cpp
@@ -137,7 +137,7 @@ void LveSwapChain::createSwapChain() {
   VkExtent2D extent = chooseSwapExtent(swapChainSupport.capabilities);
   
   // hardcoded so that devices with minImageCount = 3 have the right number of sync objects
-  uint32_t imageCount = swapChainSupport.capabilities.minImageCount = 3;
+  uint32_t imageCount = 3;
     
   if (swapChainSupport.capabilities.maxImageCount > 0 &&
       imageCount > swapChainSupport.capabilities.maxImageCount) {


### PR DESCRIPTION
On some devices, like intel integrated graphics cards, the minimum image count is 3. When adding 1 to this, there are 4 images which causes issues because the number of sync objects is hard coded as 2. Another fix for this would be to create imageCount - 1 sync objects, but that would result in quadruple buffering on the devices with 3 images.