### PR TITLE
Tut05: Take the function defaultPipelineConfigInfo() out of the class LvePipeline

### DIFF
--- a/littleVulkanEngine/tutorial05/first_app.cpp
+++ b/littleVulkanEngine/tutorial05/first_app.cpp
@@ -38,7 +38,7 @@ void FirstApp::createPipelineLayout() {
 
 void FirstApp::createPipeline() {
   PipelineConfigInfo pipelineConfig{};
-  LvePipeline::defaultPipelineConfigInfo(
+  defaultPipelineConfigInfo(
       pipelineConfig,
       lveSwapChain.width(),
       lveSwapChain.height());

--- a/littleVulkanEngine/tutorial05/lve_pipeline.cpp
+++ b/littleVulkanEngine/tutorial05/lve_pipeline.cpp
@@ -126,7 +126,7 @@ void LvePipeline::bind(VkCommandBuffer commandBuffer) {
   vkCmdBindPipeline(commandBuffer, VK_PIPELINE_BIND_POINT_GRAPHICS, graphicsPipeline);
 }
 
-void LvePipeline::defaultPipelineConfigInfo(
+void defaultPipelineConfigInfo(
     PipelineConfigInfo& configInfo, uint32_t width, uint32_t height) {
   configInfo.inputAssemblyInfo.sType = VK_STRUCTURE_TYPE_PIPELINE_INPUT_ASSEMBLY_STATE_CREATE_INFO;
   configInfo.inputAssemblyInfo.topology = VK_PRIMITIVE_TOPOLOGY_TRIANGLE_LIST;

--- a/littleVulkanEngine/tutorial05/lve_pipeline.hpp
+++ b/littleVulkanEngine/tutorial05/lve_pipeline.hpp
@@ -27,6 +27,9 @@ struct PipelineConfigInfo {
   uint32_t subpass = 0;
 };
 
+void defaultPipelineConfigInfo(
+      PipelineConfigInfo& configInfo, uint32_t width, uint32_t height);
+
 class LvePipeline {
  public:
   LvePipeline(
@@ -40,9 +43,6 @@ class LvePipeline {
   void operator=(const LvePipeline&) = delete;
 
   void bind(VkCommandBuffer commandBuffer);
-
-  static void defaultPipelineConfigInfo(
-      PipelineConfigInfo& configInfo, uint32_t width, uint32_t height);
 
  private:
   static std::vector<char> readFile(const std::string& filepath);


### PR DESCRIPTION
I found difficult to differenciate the functions createGraphicsPipeline() and defaultPipelineConfigInfo(), and then I realized that there was no need (I believe) to keep defaultPipelineConfigInfo() inside the class LvePipeline, and that keeping it outside of it, as we do with the struct PipelineConfigInfo, make things much clearer. If I am wrong, please correct me! I am willing to understand everything as good as possible! )